### PR TITLE
change isLike to isLiked

### DIFF
--- a/frontend/src/api/band/index.test.ts
+++ b/frontend/src/api/band/index.test.ts
@@ -103,7 +103,7 @@ describe('band api', () => {
 
   test(`/api/cover/like/<id:int>/`, async () => {
     const mockId = 323;
-    const mockForm = { coverId: mockId, isLike: true };
+    const mockForm = { coverId: mockId, isLiked: true };
 
     expect(await api.getCoverLike(mockId)).toEqual(MOCK_GET_DATA);
     expect(apiClient.get).lastCalledWith(`/api/cover/like/${mockId}/`);
@@ -111,7 +111,7 @@ describe('band api', () => {
     expect(await api.putCoverLike(mockForm)).toEqual(MOCK_PUT_RESPONSE);
     expect(apiClient.put).lastCalledWith(
       `/api/cover/like/${mockForm.coverId}/`,
-      { isLike: mockForm.isLike },
+      { isLiked: mockForm.isLiked },
     );
 
     expect(await api.deleteCoverLike(mockId)).toEqual(MOCK_DELETE_RESPONSE);
@@ -169,7 +169,7 @@ describe('band api', () => {
   // Basic testing
   //   test(`urlll/<id:int>/`, async () => {
   //     const mockId = 323;
-  //     const mockForm = { coverId: mockId, isLike: true };
+  //     const mockForm = { coverId: mockId, isLiked: true };
 
   //     expect(await api.getCoverLike(mockId)).toEqual(MOCK_GET_DATA);
   //     expect(apiClient.get).lastCalledWith(`urlll/${mockId}/`);

--- a/frontend/src/api/band/index.ts
+++ b/frontend/src/api/band/index.ts
@@ -70,15 +70,15 @@ export const api = {
 
   // `/api/cover/like/<id:int>/`
   getCoverLike: async (coverId: number) => {
-    const response = await apiClient.get<{ isLike: Boolean }>(
+    const response = await apiClient.get<{ isLiked: Boolean }>(
       `/api/cover/like/${coverId}/`,
     );
     return response.data;
   },
-  putCoverLike: async (form: { coverId: number; isLike: Boolean }) => {
-    return await apiClient.put<{ isLike: Boolean }>(
+  putCoverLike: async (form: { coverId: number; isLiked: Boolean }) => {
+    return await apiClient.put<{ isLiked: Boolean }>(
       `/api/cover/like/${form.coverId}/`,
-      { isLike: form.isLike },
+      { isLiked: form.isLiked },
     );
   },
   deleteCoverLike: async (coverId: number) => {


### PR DESCRIPTION
### Related Issues
<!--Write 'Fixes #(issue)' for every issue fixed-->
Fixes #68 

### Description
<!--Describe how you solved the issue for your reviewer-->

이전 PR에서 백엔드만 바꾸면 되는 줄 알고 그냥 바로 백엔드를 바꾸고 머지해버렸는데, 프론트엔드에도 isLike 들어간 API가 있어서 프론트엔드의 isLike를 isLiked로 바꿨습니다.

### Additional documentation

